### PR TITLE
fixed http imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
 
 
     <!-- jQuery Import -->
-    <script src="http://code.jquery.com/jquery-3.5.1.min.js"
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"
         integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
     <!-- Script.JS Import -->
     <script src="assets/js/script.js"></script>

--- a/main.html
+++ b/main.html
@@ -125,7 +125,7 @@
 
 
     <!-- jQuery Import -->
-    <script src="http://code.jquery.com/jquery-3.5.1.min.js"
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"
         integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
     <!-- Script.JS Import -->
     <script src="assets/js/script.js"></script>


### PR DESCRIPTION
fixed jQuery http imports.
You should always import scripts and make calls using https, never http. GitHub Pages blocks any outgoing http requests, so jQuery never gets imported this way, and because of that doesn't work.